### PR TITLE
chore: Use swagger objectmapper

### DIFF
--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/schemas/DefaultSchemasService.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/schemas/DefaultSchemasService.java
@@ -1,6 +1,5 @@
 package io.github.stavshamir.springwolf.schemas;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
@@ -18,7 +17,12 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.io.IOException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 
 @Slf4j
 @Service
@@ -31,7 +35,7 @@ public class DefaultSchemasService implements SchemasService {
 
     public DefaultSchemasService(Optional<List<ModelConverter>> externalModelConverters) {
         externalModelConverters.ifPresent(converters -> converters.forEach(converter::addConverter));
-        objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+
         SimpleModule simpleModule = new SimpleModule().addSerializer(new JsonNodeExampleSerializer());
         objectMapper.registerModule(simpleModule);
     }

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/controller/dtos/MessageDtoDeserializationTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/controller/dtos/MessageDtoDeserializationTest.java
@@ -1,6 +1,7 @@
 package io.github.stavshamir.springwolf.asyncapi.controller.dtos;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.swagger.v3.core.util.Json;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -9,12 +10,13 @@ import static java.util.Collections.singletonMap;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class MessageDtoDeserializationTest {
+    private static final ObjectMapper objectMapper = Json.mapper();
 
     @Test
     public void testCanBeSerialized() throws IOException {
         String content = "{\"headers\": { \"some-header-key\" : \"some-header-value\" }, \"payload\": { \"some-payload-key\" : \"some-payload-value\" }}";
 
-        MessageDto value = new ObjectMapper().readValue(content, MessageDto.class);
+        MessageDto value = objectMapper.readValue(content, MessageDto.class);
 
         assertThat(value).isNotNull();
         assertThat(value.getHeaders()).isEqualTo(singletonMap("some-header-key", "some-header-value"));

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/schemas/DefaultSchemasServiceTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/schemas/DefaultSchemasServiceTest.java
@@ -1,6 +1,5 @@
 package io.github.stavshamir.springwolf.schemas;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.swagger.v3.core.util.Json;
 import io.swagger.v3.oas.models.media.Schema;
@@ -26,10 +25,6 @@ public class DefaultSchemasServiceTest {
 
     private static final String EXAMPLES_PATH = "/schemas/examples";
     private static final ObjectMapper objectMapper = Json.mapper();
-
-    static {
-        objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
-    }
 
     @Test
     public void string() throws IOException, JSONException {


### PR DESCRIPTION
The swagger objectmapper uses jackson underneath.
Besides registering serializers, also the mapper is configured automatically.